### PR TITLE
Do not send `timeInForce` flag for Market orders (Fixes #8)

### DIFF
--- a/src/main/java/com/webcerebrium/binance/datatype/BinanceOrderPlacement.java
+++ b/src/main/java/com/webcerebrium/binance/datatype/BinanceOrderPlacement.java
@@ -51,10 +51,6 @@ public class BinanceOrderPlacement {
             throw new BinanceApiException("Order type is not set");
         }
         sb.append("&type=").append(type.toString());
-        if (timeInForce == null) {
-            throw new BinanceApiException("Order timeInForce is not set");
-        }
-        sb.append("&timeInForce=").append(timeInForce.toString());
         if (quantity == null || quantity.compareTo(BigDecimal.ZERO) <= 0) {
             throw new BinanceApiException("Order quantity should be bigger than zero");
         }
@@ -62,12 +58,15 @@ public class BinanceOrderPlacement {
 
         if (type == BinanceOrderType.MARKET) {
             // price should be skipped for a market order, we are accepting market price
-            // sb.append("&price=0");
+            // so should timeInForce
         } else {
             if (price == null || price.compareTo(BigDecimal.ZERO) <= 0) {
                 throw new BinanceApiException("Order price should be bigger than zero");
             }
             sb.append("&price=").append(price.toString());
+            if (timeInForce == null) {
+                sb.append("&timeInForce=").append(timeInForce.toString());
+            }
         }
 
         if (!Strings.isNullOrEmpty(newClientOrderId)) {


### PR DESCRIPTION
Currently, the `timeInForce` flag is set for all orders. However, the API does not allow us to send this flag for Market orders. 

This PR assures that a `timeInForce` flag is not sent for orders of type `MARKET`, fixing #8.

Additionally, it does not throw an error if the `timeInForce` flag is not set, as this flag is optional according to [API specifications](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#new-order--trade).
  