### PR TITLE
Adding a timeout to the http connections to avoid indefinite hangs on socket.read0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ gradle.properties
 !gradle-wrapper.jar
 
 testdb.tmp/
+
+.project
+workspace

--- a/src/main/java/com/webcerebrium/binance/api/BinanceRequest.java
+++ b/src/main/java/com/webcerebrium/binance/api/BinanceRequest.java
@@ -203,6 +203,7 @@ public class BinanceRequest {
 
         try {
             conn = (HttpsURLConnection)url.openConnection();
+            conn.setConnectTimeout(120000);
         } catch (IOException e) {
             throw new BinanceApiException("HTTPS Connection error " + e.getMessage());
         }


### PR DESCRIPTION
I've been getting timeouts like these:

"Thread-14" #26347 prio=5 os_prio=0 tid=0x0000009f0277e000 nid=0x1338 runnable [0x0000009f0857e000]
   java.lang.Thread.State: RUNNABLE
        at java.net.SocketInputStream.socketRead0(java.base@9.0.4/Native Method)
        at java.net.SocketInputStream.socketRead(java.base@9.0.4/Unknown Source)
        at java.net.SocketInputStream.read(java.base@9.0.4/Unknown Source)
        at java.net.SocketInputStream.read(java.base@9.0.4/Unknown Source)
        at sun.security.ssl.SSLSocketInputRecord.read(java.base@9.0.4/Unknown Source)
        at sun.security.ssl.SSLSocketInputRecord.decode(java.base@9.0.4/Unknown Source)
        at sun.security.ssl.SSLSocketImpl.readRecord(java.base@9.0.4/Unknown Source)
        - locked <0x00000006c3343350> (a java.lang.Object)
        at sun.security.ssl.SSLSocketImpl.readRecord(java.base@9.0.4/Unknown Source)
        at sun.security.ssl.SSLSocketImpl.performInitialHandshake(java.base@9.0.4/Unknown Source)
        - locked <0x00000006c3343448> (a java.lang.Object)
        at sun.security.ssl.SSLSocketImpl.startHandshake(java.base@9.0.4/Unknown Source)
        at sun.security.ssl.SSLSocketImpl.startHandshake(java.base@9.0.4/Unknown Source)
        at sun.net.www.protocol.https.HttpsClient.afterConnect(java.base@9.0.4/Unknown Source)
        at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(java.base@9.0.4/Unknown Source)
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(java.base@9.0.4/Unknown Source)
        - locked <0x00000006c33434c0> (a sun.net.www.protocol.https.DelegateHttpsURLConnection)
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream(java.base@9.0.4/Unknown Source)
        - locked <0x00000006c33434c0> (a sun.net.www.protocol.https.DelegateHttpsURLConnection)
        at java.net.HttpURLConnection.getResponseCode(java.base@9.0.4/Unknown Source)
        at sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(java.base@9.0.4/Unknown Source)
        at com.webcerebrium.binance.api.BinanceRequest.read(BinanceRequest.java:244)
        at com.webcerebrium.binance.api.BinanceApi.account(BinanceApi.java:369)
        at com.webcerebrium.binance.api.BinanceApi.balances(BinanceApi.java:378)
...


From my research this seems to be caused by a lack of timeout configuration on the http connection. I have added this setting to the where connections are created, with a very large timeout of 2 minutes, to avoid these hangs which go on indefinitely and can't be resolved without restarting the app.

I tested it here and the hangs are gone.

Thanks!